### PR TITLE
Fix: Companies without tag not appearing

### DIFF
--- a/src/scraper.js
+++ b/src/scraper.js
@@ -85,7 +85,7 @@ function processCompanyPage(item, result) {
 		industries[item.entityUrn] = item.localizedName;
 	else if (item.$type == 'com.linkedin.voyager.common.FollowingInfo')
 		followingItems[item.entityUrn] = item.followerCount;
-	else if (item.$type == 'com.linkedin.voyager.organization.Company' && item.tagline) {
+	else if (item.$type == 'com.linkedin.voyager.organization.Company' && (item.tagline || item.tagline === null) {
 		result.name = item.name;
 		result.tagline = item.tagline;
 		result.description = item.description;


### PR DESCRIPTION
This will fix some companies getting the error "this company or people does not exist" for companys with an empty tagline.
An alternative would be :  item.tagline!==undefined

(Companies that don't have a tagline are set to null, and everything that is not a company will be undefined)